### PR TITLE
Make TestExecutor public to support test setup and cleanup in javascript.

### DIFF
--- a/src/JSTest/ScriptElements/TestCase.cs
+++ b/src/JSTest/ScriptElements/TestCase.cs
@@ -41,7 +41,7 @@ namespace JSTest.ScriptElements
 
         public override string ToScriptFragment()
         {
-            return String.Format("return {0}();", _functionName);
+            return String.Format("{0}();", _functionName);
         }
 
         public override string ToString()

--- a/src/JSTest/ScriptElements/TestExecutor.cs
+++ b/src/JSTest/ScriptElements/TestExecutor.cs
@@ -16,7 +16,7 @@
 
 namespace JSTest.ScriptElements
 {
-    internal class TestExecutor : ScriptBlock
+    public class TestExecutor : ScriptBlock
     {
         private const String UnformattedScriptBlock =
           @"(function () {{

--- a/src/JSTest/TestScript.cs
+++ b/src/JSTest/TestScript.cs
@@ -81,7 +81,7 @@ namespace JSTest
             return RunTest(new TestExecutor(IncludeDefaultBreakpoint ? Breakpoint : NoAction, testScript, NoAction));
         }
 
-        private String RunTest(TestExecutor testExecutor)
+        public String RunTest(TestExecutor testExecutor)
         {
             String scriptFile = Path.ChangeExtension(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()), ".wsf");
 


### PR DESCRIPTION
- Changed the TestExecutor class to public, and the RunTest method to public.
- Removed the 'return' statement from TestCase.ToScriptFragment, which prevents any cleanup script from running.

These changes allow setup/cleanup scripts to be specified in an executor, and TestScript.RunTest(TestExecutor) can run setup/cleanup scripts, in addition to tests.
